### PR TITLE
feat: add renovate auto updating

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,9 +13,14 @@
     },
     {
       "enabled": false,
-      "matchUpdateTypes": ["digest", "pinDigest", "pin"],
+      "matchUpdateTypes": ["digest", "pin", "pinDigest"],
       "matchDepTypes": ["container"],
       "matchFileNames": [".github/workflows/**.yaml", ".github/workflows/**.yml"],
     },
+    {
+      "automerge": true,
+      "matchUpdateTypes": ["digest"],
+      "matchDepNames": ["ghcr.io/ublue-os/silverblue-main"],
+    }
   ]
 }

--- a/Containerfile
+++ b/Containerfile
@@ -3,7 +3,7 @@ FROM scratch AS ctx
 COPY build_files /
 
 # Base Image
-FROM ghcr.io/ublue-os/silverblue-main
+FROM ghcr.io/ublue-os/silverblue-main:latest
 
 ### MODIFICATIONS
 ## make modifications desired in your image and install packages by modifying the build.sh script

--- a/image-versions.yml
+++ b/image-versions.yml
@@ -1,0 +1,5 @@
+images:
+  - name: centos-bootc
+    image: ghcr.io/ublue-os/silverblue-main
+    tag: latest
+    digest: sha256:9cf8409b59f95ba4bea219e34395fde0d3f11d4c2abd3cdd675225472d1fb041


### PR DESCRIPTION
Ok, add the renovate app to this repo and this will fire off. This will make it so renovate pins the tags to hashes, and then will check for updates.

You can then just merge the PRs to run builds, and then p5 can show you how to automate that, or perhaps we can reuse the ublue automate bots here to automerge. 