### PR TITLE
Replace GNOME logo with a version of Adwaita Triangles

### DIFF
--- a/anaconda_config/configure_iso_anaconda.sh
+++ b/anaconda_config/configure_iso_anaconda.sh
@@ -100,14 +100,14 @@ sed -i 's/ANACONDA_PRODUCTVERSION=.*/ANACONDA_PRODUCTVERSION=""/' /usr/{,s}bin/l
 sed -i 's| Fedora| Unblue|' /usr/share/anaconda/gnome/fedora-welcome || true
 
 # Replace logos
-install -Dm644 /usr/share/pixmaps/gnome_brandmark.png "/usr/share/pixmaps/fedora-logo-small.png"
-install -Dm644 /usr/share/pixmaps/gnome_brandmark.png "/usr/share/pixmaps/fedora-logo.png"
-install -Dm644 /usr/share/pixmaps/gnome_brandmark.svg "/usr/share/pixmaps/fedora-logo-sprite.svg"
-install -Dm644 /usr/share/pixmaps/gnome_brandmark.png "/usr/share/anaconda/pixmaps/silverblue/sidebar-logo.png"
+install -Dm644 /usr/share/pixmaps/adwaita-triangles.png "/usr/share/pixmaps/fedora-logo-small.png"
+install -Dm644 /usr/share/pixmaps/adwaita-triangles.png "/usr/share/pixmaps/fedora-logo.png"
+install -Dm644 /usr/share/pixmaps/adwaita-triangles.svg "/usr/share/pixmaps/fedora-logo-sprite.svg"
+install -Dm644 /usr/share/pixmaps/adwaita-triangles.png "/usr/share/anaconda/pixmaps/silverblue/sidebar-logo.png"
 install -Dm644 /usr/share/pixmaps/gnome-boot-logo.png "/usr/share/plymouth/themes/spinner/watermark.png"
 
 sed -i 's|^Icon=.*|Icon=/usr/share/icons/hicolor/scalable/apps/org.gnome.Installer.svg|' /usr/share/applications/liveinst.desktop
-sed -i 's|fedora-logo-icon|gnome-logo-icon|' /usr/share/anaconda/gnome/fedora-welcome
+sed -i 's|fedora-logo-icon|adwaita-triangles|' /usr/share/anaconda/gnome/fedora-welcome
 sed -i 's|fedora-logo-icon|org.gnome.Installer|' /usr/share/anaconda/gnome/org.fedoraproject.welcome-screen.desktop
 
 # Interactive Kickstart

--- a/build_files/unblue_fedora.sh
+++ b/build_files/unblue_fedora.sh
@@ -57,12 +57,9 @@ install -Dm0644 -t /usr/share/applications/ mimeapps.list
 
 # Install logos
 install -Dm644 -t "/usr/share/pixmaps" /ctx/logos/gnome-boot-logo.png
-install -Dm644 -t "/usr/share/pixmaps" /ctx/logos/gnome_brandmark.png
-install -Dm644 -t "/usr/share/pixmaps" /ctx/logos/gnome_brandmark.svg
-install -Dm644 /ctx/logos/gnome_brandmark.png "/usr/share/pixmaps/fedora-logo-small.png"
-install -Dm644 /ctx/logos/gnome_brandmark.png "/usr/share/pixmaps/fedora-logo.png"
-install -Dm644 /ctx/logos/gnome_brandmark.svg "/usr/share/pixmaps/fedora-logo-sprite.svg"
-install -Dm644 /ctx/logos/gnome_brandmark.svg "/usr/share/icons/hicolor/scalable/apps/gnome-logo-icon.svg"
+install -Dm644 /ctx/logos/adwaita-triangles.png "/usr/share/pixmaps/fedora-logo-small.png"
+install -Dm644 /ctx/logos/adwaita-triangles.png "/usr/share/pixmaps/fedora-logo.png"
+install -Dm644 /ctx/logos/adwaita-triangles.svg "/usr/share/pixmaps/fedora-logo-sprite.svg"
 install -Dm644 /ctx/logos/org.gnome.Installer.svg "/usr/share/icons/hicolor/scalable/apps/org.gnome.Installer.svg"
 install -Dm644 /ctx/logos/adwaita-triangles.svg "/usr/share/icons/hicolor/scalable/apps/adwaita-triangles.svg"
 install -Dm644 /ctx/logos/adwaita-triangles.png "/usr/share/icons/hicolor/512x512/apps/adwaita-triangles.png"


### PR DESCRIPTION
Keep the plymouth boot logo, that's most likely, but use
a non-gnome logo for the rest.
